### PR TITLE
update `splitDirectories` function

### DIFF
--- a/system-filepath/lib/Filesystem/Path.hs
+++ b/system-filepath/lib/Filesystem/Path.hs
@@ -301,18 +301,11 @@ splitDirectories :: FilePath -> [FilePath]
 splitDirectories p = rootName ++ dirNames ++ fileName where
 	rootName = case pathRoot p of
 		Nothing -> []
-		r -> [asFile (rootChunk r)]
-	dirNames = map asFile (pathDirectories p)
+		r -> [empty { pathRoot = r }]
+	dirNames = map (\d -> empty { pathDirectories = [d] }) (pathDirectories p)
 	fileName = case (pathBasename p, pathExtensions p) of
 		(Nothing, []) -> []
 		_ -> [filename p]
-	
-	asFile :: Chunk -> FilePath
-	asFile c = case parseFilename c of
-		(base, exts) -> empty
-			{ pathBasename = base
-			, pathExtensions = exts
-			}
 
 -------------------------------------------------------------------------------
 -- Extensions

--- a/system-filepath/tests/FilesystemPathTests.hs
+++ b/system-filepath/tests/FilesystemPathTests.hs
@@ -353,18 +353,19 @@ test_Collapse = assertions "collapse" $ do
 
 test_SplitDirectories :: Test
 test_SplitDirectories = assertions "splitDirectories" $ do
-	let splitDirectories x = map toChar8 (P.splitDirectories (fromChar8 x))
-	
-	$expect $ equal (splitDirectories "") []
-	$expect $ equal (splitDirectories "/") ["/"]
-	$expect $ equal (splitDirectories "/a") ["/", "a"]
-	$expect $ equal (splitDirectories "/ab/cd") ["/", "ab", "cd"]
-	$expect $ equal (splitDirectories "/ab/cd/") ["/", "ab", "cd"]
-	$expect $ equal (splitDirectories "ab/cd") ["ab", "cd"]
-	$expect $ equal (splitDirectories "ab/cd/") ["ab", "cd"]
-	$expect $ equal (splitDirectories "ab/cd.txt") ["ab", "cd.txt"]
-	$expect $ equal (splitDirectories "ab/cd/.txt") ["ab", "cd", ".txt"]
-	$expect $ equal (splitDirectories "ab/./cd") ["ab", ".", "cd"]
+	let splitDirectories x = P.splitDirectories (fromChar8 x)
+	    fromChar8' = map fromChar8
+
+	$expect $ equal (splitDirectories "") (fromChar8' [])
+	$expect $ equal (splitDirectories "/") (fromChar8' ["/"])
+	$expect $ equal (splitDirectories "/a") (fromChar8' ["/", "a"])
+	$expect $ equal (splitDirectories "/ab/cd") (fromChar8' ["/", "ab/", "cd"])
+	$expect $ equal (splitDirectories "/ab/cd/") (fromChar8' ["/", "ab/", "cd/"])
+	$expect $ equal (splitDirectories "ab/cd") (fromChar8' ["ab/", "cd"])
+	$expect $ equal (splitDirectories "ab/cd/") (fromChar8' ["ab/", "cd/"])
+	$expect $ equal (splitDirectories "ab/cd.txt") (fromChar8' ["ab/", "cd.txt"])
+	$expect $ equal (splitDirectories "ab/cd/.txt") (fromChar8' ["ab/", "cd/", ".txt"])
+	$expect $ equal (splitDirectories "ab/./cd") (fromChar8' ["ab/", ".", "cd"])
 
 test_InvalidUtf8InDirectoryComponent :: Test
 test_InvalidUtf8InDirectoryComponent = assertions "invalid-utf8-in-directory-component" $ do


### PR DESCRIPTION
I propose this solution for issue #3.

In short, currently `concat . splitDirectories /= id`. 

Here is example of using `concat . splitDirectories`:

```haskell
> Filesystem.Path.concat $ splitDirectories "/path/to/file"
FilePath "//path/to/file"
```

In my commit I updated `splitDirectories` function, so now it treats root part as `pathRoot`, but not as `pathBasename`. 

I have run all testes, and here is content of log file:

```
Test suite filesystem_path_tests: RUNNING...
PASS: 47 tests run, 47 tests passed
Test suite filesystem_path_tests: PASS
Test suite logged to: dist/test/system-filepath-0.4.13.1-filesystem_path_tests.log
```

I found that there is `test_SplitDirectories` function in `FilesystemPathTests.hs` file:

```haskell
test_SplitDirectories :: Test
test_SplitDirectories = assertions "splitDirectories" $ do
	let splitDirectories x = map toChar8 (P.splitDirectories (fromChar8 x))
	
	$expect $ equal (splitDirectories "") []
	$expect $ equal (splitDirectories "/") ["/"]
	$expect $ equal (splitDirectories "/a") ["/", "a"]
	$expect $ equal (splitDirectories "/ab/cd") ["/", "ab", "cd"]
	$expect $ equal (splitDirectories "/ab/cd/") ["/", "ab", "cd"]
	$expect $ equal (splitDirectories "ab/cd") ["ab", "cd"]
	$expect $ equal (splitDirectories "ab/cd/") ["ab", "cd"]
	$expect $ equal (splitDirectories "ab/cd.txt") ["ab", "cd.txt"]
	$expect $ equal (splitDirectories "ab/cd/.txt") ["ab", "cd", ".txt"]
	$expect $ equal (splitDirectories "ab/./cd") ["ab", ".", "cd"]
```

So probably it couldn't find the problem because of `toChar8 . f . fromChar8`. Basically, that's what I get if I don't convert `toChar8`:

```haskell
> splitDirectories (fromChar8 "/")  == [fromChar8 "/"]
False
> Prelude.map toChar8 (splitDirectories (fromChar8 "/"))  == Prelude.map toChar8 [fromChar8 "/"]
True
```

Also I see that there are other places where `toChar8 . f . fromChar8` conversion is used, so I am going to check those functions as well.

Sorry for long message. 
Cheers and thanks for your awesome library! 