### PR TITLE
Add documentation about PLATFORM_PATH_FORMAT

### DIFF
--- a/system-filepath/lib/Filesystem/Path/CurrentOS.hs
+++ b/system-filepath/lib/Filesystem/Path/CurrentOS.hs
@@ -127,12 +127,20 @@ splitSearchPathString = R.splitSearchPathString currentOS
 -- | Convert a 'F.FilePath' to a platform&#x2010;specific format, suitable
 -- for use with external OS functions.
 --
+-- Note: The type @platformTextFormat@ can change depending upon the underlying
+-- compilation platform. Consider using 'toText' or 'encodeString' instead.
+-- See 'Filesystem.Path.Rules.Rules' for more information.
+--
 -- Since: 0.3
 encode :: F.FilePath -> PLATFORM_PATH_FORMAT
 encode = R.encode currentOS
 
 -- | Convert a 'F.FilePath' from a platform&#x2010;specific format, suitable
 -- for use with external OS functions.
+--
+-- Note: The type @platformTextFormat@ can change depending upon the underlying
+-- compilation platform. Consider using 'fromText' or 'decodeString' instead.
+-- See 'Filesystem.Path.Rules.Rules' for more information.
 --
 -- Since: 0.3
 decode :: PLATFORM_PATH_FORMAT -> F.FilePath

--- a/system-filepath/lib/Filesystem/Path/Internal.hs
+++ b/system-filepath/lib/Filesystem/Path/Internal.hs
@@ -107,6 +107,16 @@ directoryChunks path = pathDirectories path ++ [filenameChunk path]
 -- Rules
 -------------------------------------------------------------------------------
 
+-- | The type of @platformFormat@ for 'Rules' is conditionally selected at 
+-- compilation time. As such it is only intended for direct use with external OS
+-- functions and code that expects @platformFormat@ to be stable across platforms
+-- may fail to subsequently compile on a differing platform.
+--
+-- For example: on Windows or OSX @platformFormat@ will be 'T.Text',
+-- and on Linux it will be 'B.ByteString'.
+--
+-- If portability is a concern, restrict usage to functions which do not expose
+-- @platformFormat@ directly.
 data Rules platformFormat = Rules
 	{ rulesName :: T.Text
 	
@@ -117,6 +127,10 @@ data Rules platformFormat = Rules
 	
 	-- | Split a search path, such as @$PATH@ or @$PYTHONPATH@, into
 	-- a list of 'FilePath's.
+	--
+	-- Note: The type of @platformTextFormat@ can change depending upon the
+	-- underlying compilation platform. Consider using 'splitSearchPathString'
+	-- instead. See 'Rules' for more information.
 	, splitSearchPath :: platformFormat -> [FilePath]
 	
 	-- | splitSearchPathString is like 'splitSearchPath', but takes a string
@@ -156,12 +170,20 @@ data Rules platformFormat = Rules
 	-- | Convert a 'FilePath' to a platform&#x2010;specific format,
 	-- suitable for use with external OS functions.
 	--
+	-- Note: The type of @platformTextFormat@ can change depending upon the
+	-- underlying compilation platform. Consider using 'toText' or
+	-- 'encodeString' instead. See 'Rules' for more information.
+        --
 	-- Since: 0.3
 	, encode :: FilePath -> platformFormat
 	
 	-- | Convert a 'FilePath' from a platform&#x2010;specific format,
 	-- suitable for use with external OS functions.
 	--
+	-- Note: The type of @platformTextFormat@ can change depending upon the
+	-- underlying compilation platform. Consider using 'fromText' or
+	-- 'decodeString' instead. See 'Rules' for more information.
+        --
 	-- Since: 0.3
 	, decode :: platformFormat -> FilePath
 	


### PR DESCRIPTION
Adds documentation to the `Rules` type and `splitSearchPath`, `encode`, `decode` functions which all expose the conditionally set `PLATFORM_PATH_FORMAT`.

This hopefully clarifies to users that those function types are potentially unstable across different compilation platforms.

Fixes #12.