### PR TITLE
Add a Semigroup instance

### DIFF
--- a/system-filepath/lib/Filesystem/Path.hs
+++ b/system-filepath/lib/Filesystem/Path.hs
@@ -60,10 +60,14 @@ import qualified Prelude as Prelude
 
 import           Data.List (foldl')
 import           Data.Maybe (isJust, isNothing)
+import qualified Data.Semigroup as Sem
 import qualified Data.Monoid as M
 import qualified Data.Text as T
 
 import           Filesystem.Path.Internal
+
+instance Sem.Semigroup FilePath where
+  (<>) = append
 
 instance M.Monoid FilePath where
 	mempty = empty

--- a/system-filepath/system-filepath.cabal
+++ b/system-filepath/system-filepath.cabal
@@ -28,6 +28,9 @@ library
     , bytestring >= 0.9
     , deepseq >= 1.1 && < 1.5
     , text >= 0.11.0.6
+  if !impl(ghc >= 8.0)
+    build-depends:
+      semigroups >= 0.11 && < 0.19
 
   if os(windows)
     cpp-options: -DCABAL_OS_WINDOWS


### PR DESCRIPTION
I know the package is deprecated, but somehow something is depending on it, so why not make a fix for 8.4