### PR TITLE
Make it obvious even to GHC that `mappend` is canonical (equal to `(<>)`)

### DIFF
--- a/system-filepath/lib/Filesystem/Path.hs
+++ b/system-filepath/lib/Filesystem/Path.hs
@@ -71,7 +71,7 @@ instance Sem.Semigroup FilePath where
 
 instance M.Monoid FilePath where
   mempty = empty
-  mappend = append
+  mappend = (<>)
   mconcat = concat
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
- **Canonical definition of `mappend`**
